### PR TITLE
Debug option to run only current line of RSpec file

### DIFF
--- a/package.json
+++ b/package.json
@@ -492,6 +492,18 @@
             ]
           },
           {
+            "name": "RSpec - active spec line only",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceRoot}/bin/rspec",
+            "args": [
+              "-I",
+              "${workspaceRoot}",
+              "${file}:${lineNumber}"
+            ]
+          },
+          {
             "name": "Cucumber",
             "type": "Ruby",
             "request": "launch",


### PR DESCRIPTION
Using the existing "RSpec File" debug option, adds a "RSpec File Line" debug option.